### PR TITLE
Make hashes methods compatible with redis-rb

### DIFF
--- a/lib/protocol/redis/methods/hashes.rb
+++ b/lib/protocol/redis/methods/hashes.rb
@@ -27,6 +27,7 @@ module Protocol
 				# Get the number of fields in a hash. O(1).
 				# @see https://redis.io/commands/hlen
 				# @param key [Key]
+				# @return [Integer]
 				def hlen(key)
 					call('HLEN', key)
 				end
@@ -34,6 +35,7 @@ module Protocol
 				# Set the string value of a hash field. O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.
 				# @see https://redis.io/commands/hset
 				# @param key [Key]
+				# @return [Integer]
 				def hset(key, field, value)
 					call('HSET', key, field, value)
 				end
@@ -43,13 +45,15 @@ module Protocol
 				# @param key [Key]
 				# @param field [String]
 				# @param value [String]
+				# @return [Boolean]
 				def hsetnx(key, field, value)
-					call('HSETNX', key, field, value)
+					call('HSETNX', key, field, value) > 0
 				end
 				
 				# Set multiple hash fields to multiple values. O(N) where N is the number of fields being set.
 				# @see https://redis.io/commands/hmset
 				# @param key [Key]
+				# @return [String] default: "OK"
 				def hmset(key, *attrs)
 					call('HMSET', key, *attrs)
 				end
@@ -58,6 +62,7 @@ module Protocol
 				# @see https://redis.io/commands/hget
 				# @param key [Key]
 				# @param field [String]
+				# @return [String, Null]
 				def hget(key, field)
 					call('HGET', key, field)
 				end
@@ -66,14 +71,16 @@ module Protocol
 				# @see https://redis.io/commands/hmget
 				# @param key [Key]
 				# @param field [String]
-				def hmget(key, *fields, &blk)
-					call('HMGET', key, *fields, &blk)
+				# @return [Array]
+				def hmget(key, *fields)
+					call('HMGET', key, *fields)
 				end
 				
 				# Delete one or more hash fields. O(N) where N is the number of fields to be removed.
 				# @see https://redis.io/commands/hdel
 				# @param key [Key]
 				# @param field [String]
+				# @return [Integer]
 				def hdel(key, *fields)
 					call('HDEL', key, *fields)
 				end
@@ -82,8 +89,9 @@ module Protocol
 				# @see https://redis.io/commands/hexists
 				# @param key [Key]
 				# @param field [String]
+				# @return [Boolean]
 				def hexists(key, field)
-					call('HEXISTS', key, field)
+					call('HEXISTS', key, field) > 0
 				end
 				
 				# Increment the integer value of a hash field by the given number. O(1).
@@ -91,6 +99,7 @@ module Protocol
 				# @param key [Key]
 				# @param field [String]
 				# @param increment [Integer]
+				# @return [Integer]
 				def hincrby(key, field, increment)
 					call('HINCRBY', key, field, increment)
 				end
@@ -100,13 +109,15 @@ module Protocol
 				# @param key [Key]
 				# @param field [String]
 				# @param increment [Double]
+				# @return [Float]
 				def hincrbyfloat(key, field, increment)
-					call('HINCRBYFLOAT', key, field, increment)
+					Float(call('HINCRBYFLOAT', key, field, increment))
 				end
 				
 				# Get all the fields in a hash. O(N) where N is the size of the hash.
 				# @see https://redis.io/commands/hkeys
 				# @param key [Key]
+				# @return [Array]
 				def hkeys(key)
 					call('HKEYS', key)
 				end
@@ -114,6 +125,7 @@ module Protocol
 				# Get all the values in a hash. O(N) where N is the size of the hash.
 				# @see https://redis.io/commands/hvals
 				# @param key [Key]
+				# @return [Array]
 				def hvals(key)
 					call('HVALS', key)
 				end
@@ -121,8 +133,9 @@ module Protocol
 				# Get all the fields and values in a hash. O(N) where N is the size of the hash.
 				# @see https://redis.io/commands/hgetall
 				# @param key [Key]
+				# @return [Hash]
 				def hgetall(key)
-					call('HGETALL', key)
+					call('HGETALL', key).each_slice(2).to_h
 				end
 			end
 		end

--- a/lib/protocol/redis/methods/hashes.rb
+++ b/lib/protocol/redis/methods/hashes.rb
@@ -35,7 +35,7 @@ module Protocol
 				# Set the string value of a hash field. O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.
 				# @see https://redis.io/commands/hset
 				# @param key [Key]
-				# @return [Integer]
+				# @return [Integer] if new field added returns "1" otherwise "0"
 				def hset(key, field, value)
 					call('HSET', key, field, value)
 				end
@@ -45,7 +45,7 @@ module Protocol
 				# @param key [Key]
 				# @param field [String]
 				# @param value [String]
-				# @return [Boolean]
+				# @return [Boolean] "true" if new field added, "false" otherwise
 				def hsetnx(key, field, value)
 					call('HSETNX', key, field, value) > 0
 				end
@@ -80,7 +80,7 @@ module Protocol
 				# @see https://redis.io/commands/hdel
 				# @param key [Key]
 				# @param field [String]
-				# @return [Integer]
+				# @return [Integer] number of deleted fields
 				def hdel(key, *fields)
 					call('HDEL', key, *fields)
 				end
@@ -99,7 +99,7 @@ module Protocol
 				# @param key [Key]
 				# @param field [String]
 				# @param increment [Integer]
-				# @return [Integer]
+				# @return [Integer] field value after increment
 				def hincrby(key, field, increment)
 					call('HINCRBY', key, field, increment)
 				end
@@ -109,7 +109,7 @@ module Protocol
 				# @param key [Key]
 				# @param field [String]
 				# @param increment [Double]
-				# @return [Float]
+				# @return [Float] field value after increment
 				def hincrbyfloat(key, field, increment)
 					Float(call('HINCRBYFLOAT', key, field, increment))
 				end

--- a/spec/protocol/redis/methods/hashes_spec.rb
+++ b/spec/protocol/redis/methods/hashes_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require_relative 'helper'
+
+require 'protocol/redis/methods/hashes'
+
+RSpec.describe Protocol::Redis::Methods::Hashes do
+	let(:object) {Object.including(described_class).new}
+	let(:hash_name) { 'htest' }
+	let(:field_name) { 'field' }
+	let(:value) { 'value' }
+
+	describe '#hsetnx' do
+		it 'can generate correct arguments' do
+			expect(object).to receive(:call).with('HSETNX', hash_name, field_name, value).and_return(1)
+
+			expect(object.hsetnx(hash_name, field_name, value)).to be true
+		end
+	end
+
+	describe '#hexists' do
+		it 'can generate correct arguments' do
+			expect(object).to receive(:call).with('HEXISTS', hash_name, field_name).and_return(1)
+
+			expect(object.hexists(hash_name, field_name)).to be true
+		end
+	end
+
+	describe '#hincrbyfloat' do
+		let(:value) { 3.14 }
+
+		it 'can generate correct arguments' do
+			expect(object).to receive(:call).with('HINCRBYFLOAT', hash_name, field_name, value).and_return('3.1400000000000001')
+
+			expect(object.hincrbyfloat(hash_name, field_name, value)).to eq value
+		end
+	end
+
+	describe '#hgetall' do
+		it 'can generate correct arguments' do
+			expect(object).to receive(:call).with('HGETALL', hash_name).and_return([field_name, value, 'test', '1'])
+
+			expect(object.hgetall(hash_name)).to eq({ field_name => value, 'test' => '1' })
+		end
+	end
+end


### PR DESCRIPTION
## Description

This doesn't change any existing methods but changes returned values for them. I've checked and verified that output values now match redis-rb output.

* outline @return types
