### PR TITLE
Include sets and streams in the protocol methods

### DIFF
--- a/lib/protocol/redis/methods.rb
+++ b/lib/protocol/redis/methods.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 # Copyright, 2019, by Mikael Henriksson. <http://www.mhenrixon.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,7 +29,9 @@ require_relative 'methods/counting'
 
 require_relative 'methods/hashes'
 require_relative 'methods/lists'
+require_relative 'methods/sets'
 require_relative 'methods/strings'
+require_relative 'methods/streams'
 require_relative 'methods/sorted_sets'
 
 require_relative 'methods/pubsub'
@@ -42,14 +44,16 @@ module Protocol
 				klass.include Methods::Connection
 				klass.include Methods::Server
 				klass.include Methods::Geospatial
-				
+
 				klass.include Methods::Counting
-				
+
 				klass.include Methods::Hashes
 				klass.include Methods::Lists
+				klass.include Methods::Sets
 				klass.include Methods::SortedSets
 				klass.include Methods::Strings
-				
+				klass.include Methods::Streams
+
 				klass.include Methods::Pubsub
 			end
 		end

--- a/lib/protocol/redis/methods.rb
+++ b/lib/protocol/redis/methods.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 # Copyright, 2019, by Mikael Henriksson. <http://www.mhenrixon.com>
-#
+# 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-#
+# 
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-#
+# 
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -44,16 +44,16 @@ module Protocol
 				klass.include Methods::Connection
 				klass.include Methods::Server
 				klass.include Methods::Geospatial
-
+				
 				klass.include Methods::Counting
-
+				
 				klass.include Methods::Hashes
 				klass.include Methods::Lists
 				klass.include Methods::Sets
 				klass.include Methods::SortedSets
 				klass.include Methods::Strings
 				klass.include Methods::Streams
-
+				
 				klass.include Methods::Pubsub
 			end
 		end

--- a/spec/protocol/redis/methods_spec.rb
+++ b/spec/protocol/redis/methods_spec.rb
@@ -23,4 +23,18 @@
 require 'protocol/redis/methods'
 
 RSpec.describe Protocol::Redis::Methods do
+  context "when included" do
+    let(:constants) do
+      described_class.constants(false).map do |c|
+        described_class.const_get(c)
+      end
+    end
+
+    it "includes all other methods modules" do
+      klass = Class.new
+      expect do
+        klass.include(described_class)
+      end.to change { klass.ancestors }.to include(*constants)
+    end
+  end
 end


### PR DESCRIPTION
## Description

Async::Redis::Client is not a drop-in replacement for ::Redis due to missing methods for sets and streams. This change adds the missing modules and a simple test to ensure that any known modules at test time are properly included by the main module.

Similar to #13, but with the addition of the streams module and tests.

### Types of Changes

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [X] I added tests for my changes.
- [X] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
