### PR TITLE
Add scripting methods to client and fix script interface

### DIFF
--- a/lib/protocol/redis/methods.rb
+++ b/lib/protocol/redis/methods.rb
@@ -29,6 +29,7 @@ require_relative 'methods/counting'
 
 require_relative 'methods/hashes'
 require_relative 'methods/lists'
+require_relative 'methods/scripting'
 require_relative 'methods/sets'
 require_relative 'methods/strings'
 require_relative 'methods/streams'
@@ -49,6 +50,7 @@ module Protocol
 				
 				klass.include Methods::Hashes
 				klass.include Methods::Lists
+				klass.include Methods::Scripting
 				klass.include Methods::Sets
 				klass.include Methods::SortedSets
 				klass.include Methods::Strings

--- a/lib/protocol/redis/methods/scripting.rb
+++ b/lib/protocol/redis/methods/scripting.rb
@@ -28,7 +28,7 @@ module Protocol
 				# @see https://redis.io/commands/eval
 				# @param script [String]
 				# @param numkeys [Integer]
-				# @param key [Key]
+				# @param key [Key] Multiple keys are supported, as long as the same number of values are also provided
 				# @param arg [String]
 				def eval(*arguments)
 					call("EVAL", *arguments)
@@ -44,37 +44,12 @@ module Protocol
 					call("EVALSHA", *arguments)
 				end
 				
-				# Set the debug mode for executed scripts. O(1).
-				# @see https://redis.io/commands/script debug
-				# @param mode [Enum]
-				def script_debug(*arguments)
-					call("SCRIPT DEBUG", *arguments)
-				end
-				
-				# Check existence of scripts in the script cache. O(N) with N being the number of scripts to check (so checking a single script is an O(1) operation).
-				# @see https://redis.io/commands/script exists
-				# @param sha1 [String]
-				def script_exists(*arguments)
-					call("SCRIPT EXISTS", *arguments)
-				end
-				
-				# Remove all the scripts from the script cache. O(N) with N being the number of scripts in cache.
-				# @see https://redis.io/commands/script flush
-				def script_flush(*arguments)
-					call("SCRIPT FLUSH", *arguments)
-				end
-				
-				# Kill the script currently in execution. O(1).
-				# @see https://redis.io/commands/script kill
-				def script_kill(*arguments)
-					call("SCRIPT KILL", *arguments)
-				end
-				
-				# Load the specified Lua script into the script cache. O(N) with N being the length in bytes of the script body.
-				# @see https://redis.io/commands/script load
-				# @param script [String]
-				def script_load(*arguments)
-					call("SCRIPT LOAD", *arguments)
+				# Execute script management commands
+				# @see https://redis.io/commands/script/
+				# @param subcommand [String] e.g. `debug`, `exists`, `flush`, `load`, `kill`
+				# @param [Array<String>] args depends on the subcommand provided
+				def script(subcommand, *arguments)
+					call("SCRIPT", subcommand.to_s, *arguments)
 				end
 			end
 		end

--- a/spec/protocol/redis/methods/scripting_spec.rb
+++ b/spec/protocol/redis/methods/scripting_spec.rb
@@ -1,0 +1,105 @@
+require_relative 'helper'
+
+require 'protocol/redis/methods/scripting'
+
+RSpec.describe Protocol::Redis::Methods::Scripting do
+	let(:object) {Object.including(Protocol::Redis::Methods::Scripting).new}
+
+	describe '#eval' do
+		let(:script) {"scriptname"}
+    let(:key1) {"mykey1"}
+		let(:value1) {"myvalue1"}
+    let(:key2) {"mykey2"}
+		let(:value2) {"myvalue2"}
+
+    it "can generate correct arguments" do
+			expect(object).to receive(:call).with("EVAL", script, 1, key1, value1)
+
+			object.eval(script, 1, key1, value1)
+		end
+
+		it "can generate correct arguments with multiple keys and values" do
+			expect(object).to receive(:call).with("EVAL", script, 2, key1, key2, value1, value2)
+
+			object.eval(script, 2, key1, key2, value1, value2)
+		end
+	end
+
+	describe '#evalsha' do
+		let(:sha1) {"scriptsha"}
+    let(:key1) {"mykey1"}
+		let(:value1) {"myvalue1"}
+    let(:key2) {"mykey2"}
+		let(:value2) {"myvalue2"}
+
+		it "can generate correct arguments" do
+			expect(object).to receive(:call).with("EVALSHA", sha1, 1, key1, value1)
+
+			object.evalsha(sha1, 1, key1, value1)
+		end
+
+    it "can generate correct arguments with multiple keys and values" do
+			expect(object).to receive(:call).with("EVALSHA", sha1, 2, key1, key2, value1, value2)
+
+			object.evalsha(sha1, 2, key1, key2, value1, value2)
+		end
+	end
+
+	describe '#script' do
+		describe "#debug" do
+      let(:mode) {"YES"}
+
+      it "can generate correct arguments" do
+        expect(object).to receive(:call).with("SCRIPT", "DEBUG", mode)
+
+        object.script("DEBUG", mode)
+      end
+
+      it "will convert subcommand symbols to strings" do
+        expect(object).to receive(:call).with("SCRIPT", "debug", mode)
+
+        object.script(:debug, mode)
+      end
+    end
+
+    describe "#exists" do
+      let(:sha1) {"2ef7bde608ce5404e97d5f042f95f89f1c232871"}
+
+      it "can generate correct arguments" do
+        expect(object).to receive(:call).with("SCRIPT", "EXISTS", sha1)
+
+        object.script("EXISTS", sha1)
+      end
+    end
+
+    describe "#flush" do
+      let(:mode) {"ASYNC"}
+
+      it "can generate correct arguments" do
+        expect(object).to receive(:call).with("SCRIPT", "FLUSH", mode)
+
+        object.script("FLUSH", mode)
+      end
+    end
+
+    describe "#kill" do
+      let(:sha1) {"2ef7bde608ce5404e97d5f042f95f89f1c232871"}
+
+      it "can generate correct arguments" do
+        expect(object).to receive(:call).with("SCRIPT", "KILL")
+
+        object.script("KILL")
+      end
+    end
+
+    describe "#load" do
+      let(:script) {"return 'Hello, world!'"}
+
+      it "can generate correct arguments" do
+        expect(object).to receive(:call).with("SCRIPT", "LOAD", script)
+
+        object.script("LOAD", script)
+      end
+    end
+	end
+end


### PR DESCRIPTION
Hello! I work with Colin Kelley at Invoca and we have been using more Async in our production stack there.

When trying to use the `async-redis` gem, I found that `eval`, `evalsha`, and `script` commands were not available. 

This PR does the following:
* adds the scripting methods to the set of methods included in the `Protocol::Redis::Methods` module
* updates the `script` interface to fix the following bug:
  * When trying to use `script_load` or `script_exists` etc, Redis returns with an "unknown command" error:
```
protocol-redis-0.6.1/lib/protocol/redis/connection.rb:120:in `read_object': ERR unknown command 'SCRIPT LOAD', with args beginning with: 'return redis.call('SET', KEYS[1], ARGV[1])'  (Protocol::Redis::ServerError)
```

I went with [matching the interface](https://github.com/redis/redis-rb/blob/fde7873de430e46302869d52e23fa6fd0aab1470/lib/redis/commands/scripting.rb#L30) of `redis-rb` that defines a `script` method and treats "debug", "exists", "flush", "kill", and "load" as subcommands.

By the way, I am happy to also update the `eval` and `evalsha` interfaces to match `redis-rb` if a goal is for `async-redis` to have the same contract. For now I left it as the passthrough of all arguments untouched.

### Scripts to reproduce the issues

#### Unable to use scripting commands
```ruby
require "bundler/inline"
gemfile(true) do
  source "https://rubygems.org"

  gem "async-redis"
  gem "protocol-redis", "0.6.1" # path: "./"
end

require 'async/redis'

Sync do
  r = Async::Redis::Client.new

  # reset data
  r.mset({ "foo" => nil, "foo1" => nil, "foo2" => nil })

  puts "Load script"
  script_sha = r.script_load("return redis.call('SET', KEYS[1], ARGV[1])") # this errors out when using v0.6.1
  puts r.evalsha(script_sha, 1, "foo", "bar")
  puts r.get("foo")
end
```

#### Unable to use script_* methods

If you work around the above issue and add the scripting methods to the redis client, you then get the command error

```ruby
require "bundler/inline"
gemfile(true) do
  source "https://rubygems.org"

  gem "async-redis"
  gem "protocol-redis", "0.6.1" # path: "./"
end

require 'async/redis'

_ = Async::Redis::Client

require 'protocol/redis/methods/scripting'

module Async
  module Redis
    class Client
      include ::Protocol::Redis::Methods::Scripting
    end
  end
end

Sync do
  r = Async::Redis::Client.new

  # reset data
  r.mset({ "foo" => nil, "foo1" => nil, "foo2" => nil })

  puts "Load script"
  script_sha = r.script_load("return redis.call('SET', KEYS[1], ARGV[1])") # this errors out when using v0.6.1
  puts r.evalsha(script_sha, 1, "foo", "bar")
  puts r.get("foo")
end
```

### Integration script with the changes in this PR working:
```ruby
# frozen_string_literal: true

require "bundler/inline"
gemfile(true) do
  source "https://rubygems.org"

  gem "async-redis"
  gem "protocol-redis", path: "./"
end

require 'async/redis'

_ = Async::Redis::Client

require 'protocol/redis/methods/scripting'

module Async
  module Redis
    class Client
      include ::Protocol::Redis::Methods::Scripting
    end
  end
end

Sync do
  r = Async::Redis::Client.new

  # reset data
  r.mset({ "foo" => nil, "foo1" => nil, "foo2" => nil })

  puts "Load script"
  script_sha = r.script("load", "return redis.call('SET', KEYS[1], ARGV[1])")
  puts "Check that script exists:"
  puts r.script("exists", script_sha)

  # call script, and show that the value changed
  puts "EVALSHA of #{script_sha}"
  puts "Before: #{r.get("foo")}"
  puts r.evalsha(script_sha, 1, "foo", "bar")
  puts "After: #{r.get("foo")}"

  # remove script
  r.script("flush", "sync")
  puts "Check that script no longer exists:"
  puts r.script("exists", script_sha)

  puts "EVAL of a script"
  puts r.eval("return redis.call('MSET', KEYS[1], ARGV[1], KEYS[2], ARGV[2])", 2, "foo1", "foo2", "bar1", "bar2")
  puts "foo1: #{r.get("foo1")}"
  puts "foo2: #{r.get("foo2")}"
end
```

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
