### PR TITLE
Add cluster methods to client

### DIFF
--- a/lib/protocol/redis/methods.rb
+++ b/lib/protocol/redis/methods.rb
@@ -9,6 +9,7 @@
 require_relative 'methods/generic'
 require_relative 'methods/connection'
 require_relative 'methods/server'
+require_relative 'methods/cluster'
 require_relative 'methods/geospatial'
 
 require_relative 'methods/counting'
@@ -30,6 +31,7 @@ module Protocol
 				klass.include Methods::Generic
 				klass.include Methods::Connection
 				klass.include Methods::Server
+				klass.include Methods::Cluster
 				klass.include Methods::Geospatial
 				
 				klass.include Methods::Counting

--- a/lib/protocol/redis/methods/cluster.rb
+++ b/lib/protocol/redis/methods/cluster.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Nick Burwell.
+
+module Protocol
+  module Redis
+    module Methods
+      module Cluster
+        # Sends the `CLUSTER *` command to random node and returns its reply.
+        # @see https://redis.io/commands/cluster-addslots/
+        # @param subcommand [String, Symbol] the subcommand of cluster command
+        #   e.g. `:addslots`, `:delslots`, `:nodes`, `:replicas`, `:info`
+        #
+        # @return [Object] depends on the subcommand provided
+        def cluster(subcommand, *args)
+          call("CLUSTER", subcommand.to_s, *args)
+        end
+
+        # Sends `ASKING` command to random node and returns its reply.
+        # @see https://redis.io/commands/asking/
+        #
+        # @return [String] `'OK'`
+        def asking
+          call("ASKING")
+        end
+      end
+    end
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,14 @@ puts server.read_object
 # => "Hello World!"
 ```
 
+## Development
+
+Run tests:
+
+```
+bundle exec bake test
+```
+
 ## Contributing
 
 We welcome contributions to this project.

--- a/test/protocol/redis/methods/cluster.rb
+++ b/test/protocol/redis/methods/cluster.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2023, by Nick Burwell.
+# Copyright, 2023, by Samuel Williams.
+
+require 'methods_context'
+require 'protocol/redis/methods/cluster'
+
+describe Protocol::Redis::Methods::Cluster do
+  include_context MethodsContext, Protocol::Redis::Methods::Cluster
+
+  describe '#cluster' do
+    it "can generate correct arguments" do
+      expect(object).to receive(:call).with("CLUSTER", "info")
+
+      object.cluster(:info)
+    end
+
+    it "can generate correct arguments with multiple arguments" do
+      expect(object).to receive(:call).with("CLUSTER", "addslots", 'slot1')
+
+      object.cluster(:addslots, 'slot1')
+    end
+  end
+
+  describe '#asking' do
+    it "can generate correct call with no params" do
+      expect(object).to receive(:call).with("ASKING")
+
+      object.asking
+    end
+  end
+end

--- a/test/protocol/redis/methods/cluster.rb
+++ b/test/protocol/redis/methods/cluster.rb
@@ -25,7 +25,7 @@ describe Protocol::Redis::Methods::Cluster do
   end
 
   describe '#asking' do
-    it "can generate correct call with no params" do
+    it "can generate correct call with no parameters" do
       expect(object).to receive(:call).with("ASKING")
 
       object.asking

--- a/test/protocol/redis/methods/cluster.rb
+++ b/test/protocol/redis/methods/cluster.rb
@@ -25,7 +25,7 @@ describe Protocol::Redis::Methods::Cluster do
   end
 
   describe '#asking' do
-    it "can generate correct call with no parameters" do
+    it "can generate correct call with no arguments" do
       expect(object).to receive(:call).with("ASKING")
 
       object.asking


### PR DESCRIPTION
Adding Cluster commands to client:
*  `cluster` https://redis.io/commands/cluster-addslots/
* `asking` https://redis.io/commands/asking/

Reference in `redis-rb` gem:
[https://github.com/redis/redis-rb/blob/master/lib/redis/commands/cluster.rb](https://github.com/redis/redis-rb/blob/master/lib/redis/commands/cluster.rb)


## Types of Changes

- New feature.


## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
