### PR TITLE
Add missing hscan and add mapped_hmget & mapped_hmset

### DIFF
--- a/test/protocol/redis/methods/hashes.rb
+++ b/test/protocol/redis/methods/hashes.rb
@@ -11,13 +11,58 @@ describe Protocol::Redis::Methods::Hashes do
 	
 	let(:hash_name) {'htest'}
 	let(:field_name) {'field'}
+	let(:field2_name) {'field2'}
 	let(:value) {'value'}
+	let(:value2) {'value2'}
 
 	with '#hsetnx' do
 		it 'can generate correct arguments' do
 			expect(object).to receive(:call).with('HSETNX', hash_name, field_name, value).and_return(1)
 
 			expect(object.hsetnx(hash_name, field_name, value)).to be == true
+		end
+	end
+
+	with '#hmset' do
+		it 'can generate correct arguments' do
+			expect(object).to receive(:call).with('HMSET', hash_name, field_name, value).and_return("OK")
+
+			expect(object.hmset(hash_name, field_name, value)).to be == "OK"
+		end
+	end
+
+	with '#mapped_hmset' do
+		it 'can generate correct arguments from a hash' do
+			expect(object).to receive(:call).with('HMSET', hash_name, field_name, value).and_return("OK")
+
+			expect(object.mapped_hmset(hash_name, { field_name => value })).to be == "OK"
+		end
+	end
+
+	with '#hget' do
+		it 'can generate correct arguments' do
+			expect(object).to receive(:call).with('HGET', hash_name, field_name).and_return(value)
+
+			expect(object.hget(hash_name, field_name)).to be == value
+		end
+	end
+
+	with '#hmget' do
+		it 'can generate correct arguments' do
+			expect(object).to receive(:call).with('HMGET', hash_name, field_name, field2_name).and_return([value, value2])
+
+			expect(object.hmget(hash_name, field_name, field2_name)).to be == [value, value2]
+		end
+	end
+
+	with '#mapped_hmget' do
+		it 'can generate correct arguments and return hash' do
+			expect(object).to receive(:call).with('HMGET', hash_name, field_name, field2_name).and_return([value, value2])
+
+			expect(object.mapped_hmget(hash_name, field_name, field2_name)).to be == {
+				field_name => value,
+				field2_name => value2
+			}
 		end
 	end
 
@@ -35,7 +80,7 @@ describe Protocol::Redis::Methods::Hashes do
 		it 'can generate correct arguments' do
 			expect(object).to receive(:call).with('HINCRBYFLOAT', hash_name, field_name, value).and_return('3.1400000000000001')
 
-			expect(object.hincrbyfloat(hash_name, field_name, value)).to be ==  value
+			expect(object.hincrbyfloat(hash_name, field_name, value)).to be == value
 		end
 	end
 


### PR DESCRIPTION
This adds `hscan` as a client method.

I'm proposing that these two methods that exist in the `redis-rb` gem also be added as convenience methods ([source](https://github.com/redis/redis-rb/blob/master/lib/redis/commands/hashes.rb#L65))
* `mapped_hmget`
* `mapped_hmset`

This allows developers to store and retrieve data using Ruby hashes, and would be consistent with how `hgetall` is currently implemented in the gem, where it converts the array of data to a hash.

By the way, following up on the comment discussion in my [previous PR](https://github.com/socketry/protocol-redis/pull/16#issuecomment-1574843908), regarding `eval` and `evalsha`: in thinking about this more, I am not convinced it will be an improvement to change those interfaces to match exactly the `redis-rb` gem. Since the default behavior in this protocol-redis gem is to pass through arguments to the socket, I think the logic that `redis-rb` [added here](https://github.com/redis/redis-rb/blob/master/lib/redis/commands/scripting.rb#L56-L71) to require arrays for the keys and values (and then [plumb](https://github.com/redis/redis-rb/blob/master/lib/redis/commands/scripting.rb#L110) the `numkeys` automatically based on the length of the keys array) is more confusing than helpful.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
